### PR TITLE
fix:  remove currentField to avoid overlap

### DIFF
--- a/src/formHooks.tsx
+++ b/src/formHooks.tsx
@@ -144,6 +144,7 @@ function useForm<V = any>(
           fieldsValidating[currentField].validating = false;
         }
         setFieldsValidating({ ...fieldsValidating });
+        delete cacheData.current.currentField;
       });
   }, [values, fieldsOptions]);
 


### PR DESCRIPTION
假如上一个被修改的field是name
``` js
setFields({
   name: { value:'abc', errors:[new Error('错误')]}
});
```
会发现error没有设置成功，跟踪代码发现是 useEffect里又进行了一次validate操作导致error信息被覆盖


